### PR TITLE
TenantMiddleware made flexible with support for custom URLs

### DIFF
--- a/src/NuGet/Feijuca.Auth/Extensions/TenantMiddlewareExtension.cs
+++ b/src/NuGet/Feijuca.Auth/Extensions/TenantMiddlewareExtension.cs
@@ -1,0 +1,15 @@
+using Feijuca.Auth.Middlewares;
+using Microsoft.AspNetCore.Builder;
+
+namespace Feijuca.Auth.Extensions;
+
+public static class TenantMiddlewareExtensions
+{
+    public static IApplicationBuilder UseTenantMiddleware(this IApplicationBuilder app, Action<TenantMiddlewareOptions> configure)
+    {
+        var options = new TenantMiddlewareOptions();
+        configure(options);
+
+        return app.UseMiddleware<TenantMiddleware>(options);
+    }
+}

--- a/src/NuGet/Feijuca.Auth/Middlewares/TenantMiddleware/TenantMiddleware.cs
+++ b/src/NuGet/Feijuca.Auth/Middlewares/TenantMiddleware/TenantMiddleware.cs
@@ -3,13 +3,18 @@ using Microsoft.AspNetCore.Http;
 
 namespace Feijuca.Auth.Middlewares
 {
-    public class TenantMiddleware(RequestDelegate next)
+    public class TenantMiddleware(RequestDelegate next, TenantMiddlewareOptions options)
     {
+        private static readonly List<string> _defaultUrls = ["scalar", "openapi", "events", "favicon.ico"];
+        private readonly List<string> _availableUrls = _defaultUrls
+            .Union(options.AvailableUrls ?? Enumerable.Empty<string>(), StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+
         public async Task InvokeAsync(HttpContext context, ITenantService tenantService)
         {
             var path = context.Request.Path.Value!;
-            var availableStartingUrls = new List<string> { "scalar", "openapi", "events", "favicon.ico" };
-            if (availableStartingUrls.Exists(path.Contains))
+            if (_availableUrls.Exists(path.Contains))
             {
                 await next(context);
                 return;
@@ -22,7 +27,9 @@ namespace Feijuca.Auth.Middlewares
             {
                 context.Response.StatusCode = StatusCodes.Status400BadRequest;
                 context.Response.ContentType = "application/json";
+
                 var response = new { error = "Jwt token authorization header is required." };
+
                 await context.Response.WriteAsJsonAsync(response);
                 return;
             }

--- a/src/NuGet/Feijuca.Auth/Middlewares/TenantMiddleware/TenantMiddlewareOptions.cs
+++ b/src/NuGet/Feijuca.Auth/Middlewares/TenantMiddleware/TenantMiddlewareOptions.cs
@@ -1,0 +1,6 @@
+namespace Feijuca.Auth.Middlewares;
+
+public sealed record TenantMiddlewareOptions
+{
+    public List<string> AvailableUrls { get; init; } = [];
+}


### PR DESCRIPTION
This PR aims to make TenantMiddleware more flexible and adaptable to different scenarios, especially for public APIs or endpoints that do not require multi-tenant headers, such as third-party webhooks (e.g. Stripe, GitHub, etc.).
What was done:

- Created the TenantMiddlewareOptions record with the AvailableUrls property to configure routes that don't require the tenant header.
- Added logic to merge standard URLs with those supplied by the user via Union.
- Created UseTenantMiddleware extension method to facilitate configuration in Startup/Program.cs.

🔍 Before:

All URLs outside the fixed list within the middleware required a tenant header. There was no way to register additional exceptions for endpoints such as external webhooks.
Now:

Just configure during middleware injection:

```csharp
app.UseTenantMiddleware(options =>
{
    options.AvailableUrls = [ “webhook”, “health”, “docs” ];
});
```

This change maintains compatibility with previous behaviors (the default URLs are still preserved) and brings the flexibility that was missing to meet real use cases in production.