### PR TITLE
FEAT: create group method in Client

### DIFF
--- a/src/NuGet/Feijuca.Auth/Feijuca.Auth.csproj
+++ b/src/NuGet/Feijuca.Auth/Feijuca.Auth.csproj
@@ -36,8 +36,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mattioli.Configurations" Version="1.66.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Mattioli.Configurations" Version="1.69.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />

--- a/src/NuGet/Feijuca.Auth/Http/Client/FeijucaAuthClient.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Client/FeijucaAuthClient.cs
@@ -106,5 +106,14 @@ namespace Feijuca.Auth.Http.Client
                 _httpClient.DefaultRequestHeaders.Add("Tenant", tenant);
             }
         }
+
+        public async Task<Result> CreateGroupAsync(CreateGroupRequest request, string tenant, CancellationToken cancellationToken)
+        {
+            IncludeTenantHeader(tenant);
+
+            await PostAsync<CreateGroupRequest, bool>("groups", request, cancellationToken);
+
+            return Result.Success();
+        }
     }
 }

--- a/src/NuGet/Feijuca.Auth/Http/Client/IFeijucaAuthClient.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Client/IFeijucaAuthClient.cs
@@ -1,6 +1,7 @@
 ﻿using Mattioli.Configurations.Http;
 using Mattioli.Configurations.Models;
 using Feijuca.Auth.Http.Responses;
+using Feijuca.Auth.Http.Requests;
 
 namespace Feijuca.Auth.Http.Client;
 
@@ -12,4 +13,5 @@ public interface IFeijucaAuthClient
     Task<Result<IEnumerable<GroupResponse>>> GetGroupsAsync(string tenant, string jwtToken, CancellationToken cancellationToken);
     Task<Result<PagedResult<UserGroupResponse>>> GetGroupUsersAsync(string groupId, string jwtToken, CancellationToken cancellationToken);
     Task<Result<IEnumerable<RealmResponse>>> GetRealmsAsync(string jwtToken, CancellationToken cancellationToken);
+    Task<Result> CreateGroupAsync(CreateGroupRequest request, string tenant, CancellationToken cancellationToken);
 }

--- a/src/NuGet/Feijuca.Auth/Http/Requests/CreateGroupRequest.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Requests/CreateGroupRequest.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Feijuca.Auth.Http.Requests
+{
+    public record CreateGroupRequest(string Name);
+}


### PR DESCRIPTION
Criação do método `CreateGroupAsync` no Client para acesso ao método Post para criação de grupos no Feijuca.