### PR TITLE
FEAT: change return type in post method

### DIFF
--- a/src/Api/Feijuca.Auth.Api/Controllers/GroupsController.cs
+++ b/src/Api/Feijuca.Auth.Api/Controllers/GroupsController.cs
@@ -90,12 +90,10 @@ public class GroupsController(ICommandMediator commandMediator, IQueryMediator q
 
         if (result.IsSuccess)
         {
-            var response = Result<string>.Success("Group created successfully");
-            return Created("/createGroup", response);
+            return Created("/createGroup", result.Data);
         }
 
-        var responseError = Result<string>.Failure(result.Error);
-        return BadRequest(responseError);
+        return BadRequest(result.Error);
     }
 
     /// <summary>

--- a/src/Api/Feijuca.Auth.Api/Controllers/GroupsUsersController.cs
+++ b/src/Api/Feijuca.Auth.Api/Controllers/GroupsUsersController.cs
@@ -39,8 +39,7 @@ namespace Feijuca.Auth.Api.Controllers
                 return NoContent();
             }
 
-            var responseError = Result<string>.Failure(result.Error);
-            return BadRequest(responseError);
+            return BadRequest(result.Error);
         }
 
         /// <summary>

--- a/src/Api/Feijuca.Auth.Application/Commands/Group/AddGroupCommand.cs
+++ b/src/Api/Feijuca.Auth.Application/Commands/Group/AddGroupCommand.cs
@@ -4,5 +4,5 @@ using LiteBus.Commands.Abstractions;
 
 namespace Feijuca.Auth.Application.Commands.Group
 {
-    public record AddGroupCommand(AddGroupRequest AddGroupRequest) : ICommand<Result<bool>>;
+    public record AddGroupCommand(AddGroupRequest AddGroupRequest) : ICommand<Result<string>>;
 }

--- a/src/Api/Feijuca.Auth.Application/Commands/Group/AddGroupCommandHandler.cs
+++ b/src/Api/Feijuca.Auth.Application/Commands/Group/AddGroupCommandHandler.cs
@@ -5,23 +5,18 @@ using Feijuca.Auth.Providers;
 
 namespace Feijuca.Auth.Application.Commands.Group
 {
-    public class AddGroupCommandHandler(IGroupRepository groupRepository, ITenantProvider tenantProvider) : ICommandHandler<AddGroupCommand, Result<bool>>
+    public class AddGroupCommandHandler(IGroupRepository groupRepository, ITenantProvider tenantProvider) : ICommandHandler<AddGroupCommand, Result<string>>
     {
         private readonly IGroupRepository _groupRepository = groupRepository;
 
-        public async Task<Result<bool>> HandleAsync(AddGroupCommand request, CancellationToken cancellationToken)
+        public async Task<Result<string>> HandleAsync(AddGroupCommand request, CancellationToken cancellationToken)
         {
             var result = await _groupRepository.CreateAsync(request.AddGroupRequest.Name,
                 tenantProvider.Tenant.Name,
                 request.AddGroupRequest.Attributes, 
                 cancellationToken);
 
-            if (result.IsSuccess)
-            {
-                return Result<bool>.Success(true);
-            }
-
-            return Result<bool>.Failure(result.Error);
+            return result;
         }
     }
 }

--- a/src/NuGet/Feijuca.Auth.Api.Tests/Feijuca.Auth.Api.Tests.csproj
+++ b/src/NuGet/Feijuca.Auth.Api.Tests/Feijuca.Auth.Api.Tests.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Flurl" Version="4.0.0" />
-    <PackageReference Include="Mattioli.Configurations" Version="1.66.1" />
+    <PackageReference Include="Mattioli.Configurations" Version="1.69.0" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.13.0" />
   </ItemGroup>
 

--- a/src/NuGet/Feijuca.Auth/Feijuca.Auth.csproj
+++ b/src/NuGet/Feijuca.Auth/Feijuca.Auth.csproj
@@ -36,8 +36,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mattioli.Configurations" Version="1.66.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Mattioli.Configurations" Version="1.69.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />

--- a/src/NuGet/Feijuca.Auth/Http/Client/FeijucaAuthClient.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Client/FeijucaAuthClient.cs
@@ -106,5 +106,14 @@ namespace Feijuca.Auth.Http.Client
                 _httpClient.DefaultRequestHeaders.Add("Tenant", tenant);
             }
         }
+
+        public async Task<Result> CreateGroupAsync(CreateGroupRequest request, string tenant, CancellationToken cancellationToken)
+        {
+            IncludeTenantHeader(tenant);
+
+            await PostAsync<CreateGroupRequest, bool>("groups", request, cancellationToken);
+
+            return Result.Success();
+        }
     }
 }

--- a/src/NuGet/Feijuca.Auth/Http/Client/FeijucaAuthClient.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Client/FeijucaAuthClient.cs
@@ -115,5 +115,35 @@ namespace Feijuca.Auth.Http.Client
 
             return Result.Success();
         }
+
+        public async Task<Result<Guid>> CreateUserAsync(CreateUserRequest request, string tenant, CancellationToken cancellationToken)
+        {
+            IncludeTenantHeader(tenant);
+
+            var userId = await PostAsync<CreateUserRequest, Guid>("users", request, cancellationToken);
+
+            return Result<Guid>.Success(userId);
+        }
+
+        public async Task<Result<IEnumerable<RealmResponse>>> GetClientsRolesAsync(string jwtToken, CancellationToken cancellationToken)
+        {
+            var result = await GetAsync<IEnumerable<RealmResponse>>("clients-roles", jwtToken, cancellationToken);
+
+            return Result<IEnumerable<RealmResponse>>.Success(result);
+        }
+
+        public async Task<Result> AddRoleToGroup(string id, AddClientRoleToGroupRequest request, CancellationToken cancellationToken)
+        {
+            var result = await PostAsync<AddClientRoleToGroupRequest, bool>($"groups-roles/{id}/role", request, cancellationToken);
+
+            return Result.Success();
+        }
+
+        public async Task<Result> AddUserToGroup(AddUserToGroupRequest request, CancellationToken cancellationToken)
+        {
+            var result = await PostAsync<AddUserToGroupRequest, bool>($"groups/users", request, cancellationToken);
+
+            return Result.Success();
+        }
     }
 }

--- a/src/NuGet/Feijuca.Auth/Http/Client/IFeijucaAuthClient.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Client/IFeijucaAuthClient.cs
@@ -13,5 +13,9 @@ public interface IFeijucaAuthClient
     Task<Result<IEnumerable<GroupResponse>>> GetGroupsAsync(string tenant, string jwtToken, CancellationToken cancellationToken);
     Task<Result<PagedResult<UserGroupResponse>>> GetGroupUsersAsync(string groupId, string jwtToken, CancellationToken cancellationToken);
     Task<Result<IEnumerable<RealmResponse>>> GetRealmsAsync(string jwtToken, CancellationToken cancellationToken);
+    Task<Result<IEnumerable<RealmResponse>>> GetClientsRolesAsync(string jwtToken, CancellationToken cancellationToken);
     Task<Result> CreateGroupAsync(CreateGroupRequest request, string tenant, CancellationToken cancellationToken);
+    Task<Result<Guid>> CreateUserAsync(CreateUserRequest request, string tenant, CancellationToken cancellationToken);
+    Task<Result> AddRoleToGroup(string id, AddClientRoleToGroupRequest request, CancellationToken cancellationToken);
+    Task<Result> AddUserToGroup(AddUserToGroupRequest request, CancellationToken cancellationToken);
 }

--- a/src/NuGet/Feijuca.Auth/Http/Client/IFeijucaAuthClient.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Client/IFeijucaAuthClient.cs
@@ -1,6 +1,7 @@
 ﻿using Mattioli.Configurations.Http;
 using Mattioli.Configurations.Models;
 using Feijuca.Auth.Http.Responses;
+using Feijuca.Auth.Http.Requests;
 
 namespace Feijuca.Auth.Http.Client;
 
@@ -12,4 +13,5 @@ public interface IFeijucaAuthClient
     Task<Result<IEnumerable<GroupResponse>>> GetGroupsAsync(string tenant, string jwtToken, CancellationToken cancellationToken);
     Task<Result<PagedResult<UserGroupResponse>>> GetGroupUsersAsync(string groupId, string jwtToken, CancellationToken cancellationToken);
     Task<Result<IEnumerable<RealmResponse>>> GetRealmsAsync(string jwtToken, CancellationToken cancellationToken);
+    Task<Result> CreateGroupAsync(CreateGroupRequest request, string tenant, CancellationToken cancellationToken);
 }

--- a/src/NuGet/Feijuca.Auth/Http/Requests/AddClientRoleToGroupRequest.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Requests/AddClientRoleToGroupRequest.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Feijuca.Auth.Http.Requests
+{
+    public record AddClientRoleToGroupRequest(string ClientId, Guid RoleId);
+}

--- a/src/NuGet/Feijuca.Auth/Http/Requests/AddUserToGroupRequest.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Requests/AddUserToGroupRequest.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Feijuca.Auth.Http.Requests
+{
+    public record AddUserToGroupRequest(Guid UserId, Guid GroupId);
+}

--- a/src/NuGet/Feijuca.Auth/Http/Requests/CreateGroupRequest.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Requests/CreateGroupRequest.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Feijuca.Auth.Http.Requests
+{
+    public record CreateGroupRequest(string Name);
+}

--- a/src/NuGet/Feijuca.Auth/Http/Requests/CreateUserRequest.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Requests/CreateUserRequest.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Feijuca.Auth.Http.Requests
+{
+    internal class CreateUserRequest
+    {
+    }
+}

--- a/src/NuGet/Feijuca.Auth/Http/Responses/GroupRolesResponse.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Responses/GroupRolesResponse.cs
@@ -1,0 +1,4 @@
+﻿namespace Feijuca.Auth.Http.Responses
+{
+    public record GroupRolesResponse(string Id, string Client, IEnumerable<RoleResponse> Mappings);
+}

--- a/src/NuGet/Feijuca.Auth/Http/Responses/RoleResponse.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Responses/RoleResponse.cs
@@ -1,0 +1,4 @@
+﻿namespace Feijuca.Auth.Http.Responses
+{
+    public record RoleResponse(Guid Id, string Name, string Description, bool Composite, bool ClientRole, string ContainerId);
+}


### PR DESCRIPTION
Alterado os tipos de retorno dos métodos CreateGroup e o seu Handler, e alteração do retorno do método AddUserToGroup. Anteriormente o método retornava um Result, impedindo a serialização.

<img width="1253" height="246" alt="image" src="https://github.com/user-attachments/assets/da5e671d-c2fe-4553-b96b-d47eb29d8e84" />
<img width="1288" height="337" alt="image" src="https://github.com/user-attachments/assets/8b3ebbde-025b-4f0c-975a-24442d8e8d70" />
<img width="1277" height="267" alt="image" src="https://github.com/user-attachments/assets/a6c63d18-ee6e-4f85-a523-69aadf806df5" />

